### PR TITLE
Fast export feature (md2html) ready to merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,25 @@
+pull_request_rules:
+  - name: automatic merge
+    conditions:
+      - label!=DNM
+      - '#approved-reviews-by>=1'
+      - 'status-success=Testing: Travis CI - Pull Request'
+    actions:
+      merge:
+        method: rebase
+        rebase_fallback: merge
+        strict: smart
+      dismiss_reviews: {}
+      delete_head_branch: {}
+  - name: automatic merge on skip ci
+    conditions:
+      - label!=DNM
+      - title~=\[skip ci\]
+      - '#approved-reviews-by>=2'
+    actions:
+      merge:
+        method: rebase
+        rebase_fallback: merge
+        strict: smart
+      dismiss_reviews: {}
+      delete_head_branch: {}

--- a/README.md
+++ b/README.md
@@ -4,33 +4,67 @@ Vim-Notes
 _Yet another note plugin for VIM_
 
 _Working in progress..._
-________
+______
 Commands
 ---
 | Command | Description |
 |---|---|
 |**:Note**&nbsp;_filename_      | This command creates a new Note buffer. This is saved in a new file inside the folder g:notes_folder (set to ~/.notes by default). If no extension is specified the new file will be created with '.note' and it will be processed in the editor using the _markdown_ syntax highlighting. |
 |**:NoteList**             | Shows all the notes available inside the folder g:notes_folder |
-|**:NoteDelete**&nbsp;_filename_ </code>|  Delete a note |
+|**:NoteDelete**&nbsp;_filename_|  Delete a note |
 |**:NoteAutoSaveToggle** | Activate/Deactivate automatic save for the current _.note_ buffer |
 
 ______
 Parameters
 ---
 | Parameter | Default Value | Description |
-|-----------|---------------|-------------|
+|-----------|:-------------:|-------------|
 |g:notes_folder| ~/.notes   | Folder containing the notes |
 |g:notes_autosave| 0        | Enable/Disable the autosave of the notes |
 |g:notes_autosave_time| 30  | Defines the minimum interval between 2 successive automatic saves |
-________
+|g:notes_compiler| markdown   | Defines the compiler for note files |
+|g:notes_export_folder| ~/.notes/md2html   | Folder containing the exported notes |
+|g:default_keymap| 1   | Load the default plugin keymap |
 
 
-ToDo
+______
+
+
+Editing key mapping
 ---
-- Autosave
-- Proper README
-- Fast CheckBox
-- Scratch notes
-- Fast Export
-- Synchronization
+|Combination | Modes   | Name function | Description |
+|------------| :-----: | :-----------: | ----------- |
+|&lt;_leader_&gt;&nbsp;+&nbsp;[i| I / N   | note-new-cbox-inline | Create a new checkbox inline |
+|&lt;_leader_&gt;&nbsp;+&nbsp;[o| I / N   | note-new-cbox-below  | Create a new checkbox in the line below the current one|
+|&lt;_leader_&gt;&nbsp;+&nbsp;[O| I / N   | note-new-cbox-above | Create a new checkbox in the line above the current one|
+|&lt;_leader_&gt;&nbsp;+&nbsp;[x|  N      | notes#toggle_checkbox | Toggle the state of the checkbox between done and undone ([x]/[ ])|
 
+______
+
+
+Fast Export key mapping
+---
+|Combination | Modes   | Name function | Description |
+|------------| :-----: | :-----------: | ----------- |
+|&lt;_leader_&gt;&nbsp;+&nbsp;[e| N   | notes#export | Export the current note buffer in a specified folder|
+
+
+Key mapping override
+---
+The plugin sets by default all the described key mappings, but this can be easily disabled.
+For instance, if you want your set of customized keybindings, you can just edit the vimrc as follows:
+
+    "Disable the default key mapping
+    let g:default_keymap = 0
+
+    "Apply your own key mapping
+    nmap <Leader>ni (note-new-cbox-inline)
+    nmap <Leader>ni (note-new-cbox-inline)
+    imap <Leader>ni (note-new-cbox-inline)
+    nmap <Leader>no (note-new-cbox-below)
+    imap <Leader>no (note-new-cbox-below)
+    nmap <Leader>nO (note-new-cbox-above)
+    imap <Leader>nO (note-new-cbox-above)
+    nmap <Leader>nx :call notes#toggle_checkbox(line('.'))<cr>
+    " Fast Export function
+    nmap <leader>ne :call notes#export() <cr>

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,9 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/vim_notes_spec.rb'
 end
 
-task :default => :spec
+RSpec::Core::RakeTask.new(:cbox) do |t|
+  t.pattern = 'spec/fast_export_spec.rb'
+end
 
+task :default => :spec
 

--- a/TODO
+++ b/TODO
@@ -1,0 +1,9 @@
+TODO
+---
+
+~ Autosave ~
+- Proper README ~
+- Fast CheckBox ~
+- Fast Export ~
+- Scratch notes
+- Synchronization

--- a/autoload/notes.vim
+++ b/autoload/notes.vim
@@ -1,9 +1,33 @@
+" notes.vim -  A vim plugin to take notes easily
+" Mantainers: fmount,saro
+" Version: 1.0
+" AutoInstall: notes.vim
+" ====== Enjoy ======
 
+" Print the current version
 function notes#version()
-    echom "version " . g:notes_version
+	echom "version " . g:notes_version
 endfunction
 
+" This function is called when a buffer is created
+" or opened and pushes some default keybindings for
+" the plugin.
+" Set 'g:default_keymap = 0' to turn off the default
+" keybindings
+function notes#defaultkeymap()
+	" Add checkbox creating/marking key maps
+	nmap <buffer> <Leader>[i (note-new-cbox-inline)
+	imap <buffer> <Leader>[i (note-new-cbox-inline)
+	nmap <buffer> <Leader>[o (note-new-cbox-below)
+	imap <buffer> <Leader>[o (note-new-cbox-below)
+	nmap <buffer> <Leader>[O (note-new-cbox-above)
+	imap <buffer> <Leader>[O (note-new-cbox-above)
+	nmap <buffer> <Leader>[x :call notes#toggle_checkbox(line('.'))<cr>
+	" Fast Export function
+	nmap <leader>[e :call notes#export() <cr>
+endfunction
 
+" Create a new note or open an existing one
 function notes#edit(filename)
 	let l:dir =  expand(g:notes_folder)
 	let l:tmpfilename = a:filename
@@ -47,7 +71,6 @@ endfunction
 function notes#delete(...)
 	if(exists('a:1'))
 		let note = a:1
-
 		"Check for the working directory
 		if(expand(g:notes_folder) != fnamemodify(expand(note, '/'), ':h'))
 			echomsg "Working directory doesn't match"
@@ -71,12 +94,11 @@ function notes#delete(...)
 		echo "Failed to delete " . note
 		echohl None
 	endif
-
 	return delStatus
 endfunction
 
 
-" Autosave for buffered notes 
+" Autosave for buffered notes
 function notes#update_buffer()
 	"echomsg "Time elapsed: ".(localtime()-b:notes_start_time) "DEBUG TIME
 	let l:note_time_elapsed = localtime() - b:notes_start_time
@@ -84,7 +106,7 @@ function notes#update_buffer()
 	" check for the time elapsed, the value of the autosave variable and
 	" the current file type (through the .note extension)
 	if(matchstr(expand('%.t'),'\^*.note$') != "" && g:notes_autosave >= 1
-                \&& l:note_time_elapsed >= g:notes_autosave_time)
+				\&& l:note_time_elapsed >= g:notes_autosave_time)
 
 		"Try to update the buffer if modified
 		let was_modified = &modified
@@ -94,7 +116,6 @@ function notes#update_buffer()
 			echomsg "(AutoSaved at " . strftime("%H:%M:%S") . ")"
 			let b:notes_start_time = localtime()
 		endif
-
 	endif
 endfunction
 
@@ -109,3 +130,30 @@ function notes#autosave_toggle()
 	endif
 endfunction
 
+" Fill or clean the checkbox where the cursor is present
+function notes#toggle_checkbox(linenr)
+	if (empty(matchstr(getline(a:linenr), '^\s*\[\s\].*$')) == 0)
+		:s/^\s*\[\s\]/\1[x]
+	elseif (empty(matchstr(getline(a:linenr), '^\s*\[x\].*$')) == 0)
+		:s/^\s*\[x\]/\1[ ]
+	endif
+endfunction
+
+" Markdown2HTML export function
+function notes#export()
+	let l:dest_dir = expand(g:notes_export_folder)
+	if executable(g:notes_compiler)
+		" Create g:notes_export_folder if not existing
+		if !isdirectory(l:dest_dir)
+			call mkdir(l:dest_dir,'p')
+		endif
+		if(matchstr(bufname('%'),'\^*.note$') != "")
+			echom system(g:notes_compiler . " " . bufname('%') . ">> " . g:notes_export_folder . "/" . expand('%:t:r') . '.html')
+		else
+			echom 'Provide a .note file'
+		endif
+	else
+		echom "No " . g:notes_compiler . " found"
+	endif
+	echom "Note " . bufname('%') . " exported"
+endfunction

--- a/plugin/notes.vim
+++ b/plugin/notes.vim
@@ -1,20 +1,16 @@
 " notes.vim -  A vim plugin to take notes easily
-" Mantainer: fmount
+" Mantainer: fmount, saro
 " Version: 1.0
 " AutoInstall: notes.vim
 " ====== Enjoy ======
-"
 
-if exists('g:loaded_notes') || &cp
+"For security reasons check the vim version
+if v:version < 702
+	echomsg 'notes: You need at least Vim 7.2'
 	finish
 endif
 
-let g:loaded_notes = 0
-let g:notes_version = '1.0'
-
-"For security reasons..
-"if v:version < 702
-"	echomsg 'notes: You need at least Vim 7.2'
+"if exists('g:loaded_notes') || &cp
 "	finish
 "endif
 
@@ -22,23 +18,51 @@ if !exists('g:notes_folder')
 	let g:notes_folder = "~/.notes"
 endif
 
-if !exists("g:notes_autosave")
+if !exists('g:notes_autosave')
 	let g:notes_autosave = 0
 	let g:notes_autosave_time = 10 "seconds
 endif
 
+if !exists('g:notes_compiler')
+	let g:notes_compiler = 'markdown'
+endif
+
+if !exists('g:notes_export_folder')
+	let g:notes_export_folder = '~/.notes/md2html'
+endif
+
+if !exists('g:default_keymap')
+    let g:default_keymap = 1
+endif
+
+"let g:loaded_notes = 0
+let g:notes_version = '1.0'
+"let g:default_keymap = 1
+
+" Create a new item
+nnore (note-new-cbox-inline) I[ ]<space>
+inore (note-new-cbox-inline) <Esc>I[ ]<space>
+
+" Create a new item below
+nnore (note-new-cbox-below) $o[ ]<space>
+inore (note-new-cbox-below) <Esc>$o[ ]<space>
+
+" Create a new item above
+nnore (note-new-cbox-above) $O[ ]<space>
+inore (note-new-cbox-above) <Esc>$O[ ]<space>
+
 augroup bufferset
 	autocmd!
 	autocmd BufRead,BufNewFile *.note set filetype=markdown
+	autocmd BufRead,BufNewFile *.note if g:default_keymap | call notes#defaultkeymap() | endif
 	autocmd BufRead,BufNewFile *.note let b:notes_start_time=localtime()
-	"autocmd BufRead,BufNewFile   *.* syntax on
 	"Autosave settings
 	autocmd CursorHold,BufRead *.note call notes#update_buffer()
 	autocmd BufWritePre *.note let b:notes_start_time = localtime()
 augroup END
 
-
 command! -complete=customlist,notes#navigate -nargs=1 Note call notes#edit(<f-args>)
 command! -complete=customlist, NoteList call notes#list()
 command! -complete=customlist,notes#navigate -nargs=1 NoteDelete call notes#delete(<f-args>) | bdelete!
 command! NoteAutoSaveToggle :call notes#autosave_toggle()
+

--- a/spec/fast_export_spec.rb
+++ b/spec/fast_export_spec.rb
@@ -1,0 +1,44 @@
+# -*- encoding: utf-8 -*-
+require 'spec_helper'
+
+describe "notes#cboxes" do
+  let(:filename) { 'test.note' }
+  specify "#create item inline" do
+    before <<-EOF
+    EOF
+    vim.normal 'I[ ]'
+    after <<-EOF
+    [ ]
+    EOF
+  end
+  specify "#create item below" do
+    before <<-EOF
+    [ ]
+    EOF
+    vim.normal 'o[ ]'
+    after <<-EOF
+    [ ]
+    [ ]
+    EOF
+  end
+  specify "#create item above" do
+    before <<-EOF
+    [ ]
+    EOF
+    vim.normal 'O[ ]'
+    after <<-EOF
+    [ ]
+    [ ]
+    EOF
+  end
+  specify "#toggle checkbox" do
+    before <<-EOF
+    [ ]
+    EOF
+    vim.command("call notes#toggle_checkbox(line('.'))")
+    after <<-EOF
+    [x]
+    EOF
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,36 @@
 require 'vimrunner'
 require 'vimrunner/rspec'
 
+def set_file_content(string)
+  string = normalize_string_indent(string)
+  File.open(filename, 'w'){ |f| f.write(string) }
+  vim.edit filename
+end
+
+def get_file_content()
+  vim.write
+  IO.read(filename).strip
+end
+
+def before(string)
+  set_file_content(string)
+end
+
+def after(string)
+  get_file_content().should eq normalize_string_indent(string)
+  type ":q<CR>"
+end
+
+def type(string)
+  string.scan(/<.*?>|./).each do |key|
+    if /<.*>/.match(key)
+      vim.feedkeys "\\#{key}"
+    else
+      vim.feedkeys key
+    end
+  end
+end
+
 Vimrunner::RSpec.configure do |config|
 
   # Use a single Vim instance for the test suite. Set to false to use an

--- a/spec/vim_notes_spec.rb
+++ b/spec/vim_notes_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe "notes#edit" do
   it "returns a new Note if you open a new buffer" do
     vim.command('call notes#edit("test")')
-    vim.edit "test.note"
+    #vim.edit "test.note"
     vim.insert("This is a simple test note")
     vim.write
   end


### PR DESCRIPTION
Since we need to enable the cbox mappings in different scenarios (e.g. :e *.notes), the cbox mapping is moved in a init function, so we can handle better the init phase when *BufRead* and *BufNewFile* events occur.
The feature is also rebased on master and all the core functions are moved in autoload section.
